### PR TITLE
fix/delete-local-properties

### DIFF
--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Mon Mar 06 10:22:26 MST 2023
-sdk.dir=C\:\\Users\\10673\\AppData\\Local\\Android\\Sdk


### PR DESCRIPTION
Deleting local.properties on root as it can cause issues with compiling on local machines. (ie. the file is used to point to the Android SDK through which location differs by OS).

Since the file was added to the branch_after_ the .gitignore file, it should NOT cause issues IF you did _not_ pull the dev branch. If you did, just copy the same file from any Android Studio project and put it in the project root. Any subsequent pushes will not put the file back to the branch, but will keep it on your computer.