### PR TITLE
Fix / Make ZXing scanner open in portrait orientation always

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,7 +28,10 @@
         </activity>
         <activity android:name="com.example.theexplorer.ui.scan.ZXingScannerScan" />
         <activity android:name="com.example.theexplorer.ui.home.ScoresFragment" />
-
+        <activity
+            android:name="com.journeyapps.barcodescanner.CaptureActivity"
+            android:screenOrientation="portrait"
+            tools:replace="screenOrientation" />
     </application>
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>


### PR DESCRIPTION
It's petty but it's now in portrait orientation.


![Screenshot_20230313_001748](https://user-images.githubusercontent.com/71676291/224622351-7abb7975-fa49-460d-be7c-c4b18c39230e.png)
