### PR TITLE
scoring depend on ascii code for letters and numbers

### DIFF
--- a/app/src/main/java/com/example/theexplorer/ui/scan/ZXingScannerScan.java
+++ b/app/src/main/java/com/example/theexplorer/ui/scan/ZXingScannerScan.java
@@ -364,6 +364,15 @@ public class ZXingScannerScan extends AppCompatActivity implements LocationListe
             if (c == '&' || c == '=' || c == '/') {
                 theScore++;
             }
+            for(int i=48; i<57;i++){
+                if(c == (char)i){
+                    theScore+=(i-48);
+                }
+            }
+            if (c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z') {
+                theScore += (int) c;
+            }
+
         }
         theScore += content.length();
         return theScore;

--- a/local.properties
+++ b/local.properties
@@ -5,4 +5,4 @@
 # For customization when using a Version Control System, please read the
 # header note.
 #Mon Mar 13 13:38:41 MDT 2023
-sdk.dir=/Users/smag/Library/Android/sdk
+sdk.dir=C\:\\Users\\10673\\AppData\\Local\\Android\\Sdk


### PR DESCRIPTION
Scoring are now changed. The only case that will give the same score is 2 different qr codes have the same letters and numbers but in different position. The only way to solve this is using hash to calculate score. But the numbers may be so big to put into a integer. I think this way is enough for our project.