### PR TITLE
fix: resizing text in leaderboard

### DIFF
--- a/app/src/main/res/layout/adapter_leaderboard_content.xml
+++ b/app/src/main/res/layout/adapter_leaderboard_content.xml
@@ -14,17 +14,18 @@
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:layout_gravity="center_vertical">
 
         <TextView android:id="@+id/leaderboard_title"
-            android:textSize="25sp"
+            android:textSize="16sp"
             android:textStyle="bold"
             android:textColor="?android:textColorPrimary"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
 
         <TextView android:id="@+id/leaderboard_subtitle"
-            android:textSize="25sp"
+            android:textSize="16sp"
             android:textColor="?android:textColorPrimary"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>


### PR DESCRIPTION
fitting qrcode name text per line in leaderboard